### PR TITLE
Add pandas to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ pyyaml
 progressbar2
 tqdm
 ftfy
+pandas
 
 # Text processing
 unidecode


### PR DESCRIPTION
This PR addresses a ModuleNotFoundError: No module named 'pandas' that occurs during the initialization of the ComfyUI-AudioSR node.

Although pandas is not explicitly used in the top-level node logic, it is a required dependency for the underlying CLAP training and data processing modules located within versatile_audio_super_resolution/audiosr/clap/training/data.py.

While some users may have pandas already installed via other custom nodes or global site-packages, it is not part of the base Python environment for many users

Closes #9