### PR TITLE
Update model files caching logic

### DIFF
--- a/vasr_node.py
+++ b/vasr_node.py
@@ -333,10 +333,10 @@ class VASRNode:
                 pass  # Directory doesn't exist yet
 
             # Add default option if no models found
-            if not model_files:
+            if model_files:
+                _model_files_cache = model_files
+            else:
                 model_files = ["basic (download required)", "speech (download required)"]
-
-            _model_files_cache = model_files
 
         return {
             "required": {


### PR DESCRIPTION
The issue comes from caching the fallback values when no AudioSR model is detected during the initial scan.

Current behavior:

```python
if not model_files:
    model_files = ["basic (download required)", "speech (download required)"]

_model_files_cache = model_files
```

Problem:
If the models directory is empty or scanned before the `.safetensors` files are copied, the fallback values (`"speech (download required)"`) are cached permanently for the current session.

As a result:

* the workflow may save `"speech (download required)"` instead of the actual filename
* reloading the workflow later triggers the `"Model not found"` exception
* restarting ComfyUI is required to refresh the cache

Proposed fix:

```python
if model_files:
    _model_files_cache = model_files
else:
    model_files = ["basic (download required)", "speech (download required)"]
```

Behavior after the fix:

* fallback entries are no longer cached
* the node can rescan the directory later and detect newly added models
* workflows are less likely to persist invalid `"download required"` entries
* avoids requiring a full ComfyUI restart after copying model files

This change only affects model discovery/UI caching logic. It does not modify AudioSR inference or processing behavior.

Close #16 16